### PR TITLE
Add Bresser 433 MHz temperature and humidity sensor support

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,6 +14,7 @@
 		"Weather sensor",
 		"Alecto",
 		"Auriol",
+		"Bresser",
 		"Cresta",
 		"Esic",
 		"Labs",
@@ -1019,6 +1020,28 @@
 				"sensitivity": 0.2,
 				"minimalLength": 39,
 				"maximalLength": 40
+			},
+			"Bresser": {
+				"sof": [
+					1950,
+					1950,
+					1950,
+					3900
+				],
+				"eof": [],
+				"words": [
+					[
+						1950,
+						1950
+					],
+					[
+						1950,
+						3900
+					]
+				],
+			"sensitivity": 0.35,
+			"minimalLength": 72,
+			"maximalLength": 72
 			},
 			"Cresta": {
 				"sof": [

--- a/app.json
+++ b/app.json
@@ -48,6 +48,10 @@
 			{
 				"name": "Damien Villeneuve",
 				"email": "contact@dvilleneuve.fr"
+			},
+			{
+				"name": "Artur Łukowski",
+				"email": "arlukowski@gmail.com"
 			}
 		]
 	},

--- a/node_modules/protocols/bresser.js
+++ b/node_modules/protocols/bresser.js
@@ -1,0 +1,125 @@
+"use strict";
+
+const utils = require('utils');
+ 
+ /**
+ * Bresser 433 MHz (TX-8300 style)
+ *
+ * Input parse(payLoad):
+ *  - payLoad is an array of demodulated bits ('0'/'1' as strings, or 0/1),
+ *    provided by the Homey RF signal layer (getSignal433('Bresser')).
+ *  - The RF signal definition for 'Bresser' effectively extracts the payload bits from the
+ *    transmitted frame and strips the preamble: the over-the-air frame is 74 bits, but Homey
+ *    delivers 72 payload bits here (9 bytes).
+ *
+ * Algorithm:
+ *  - Interpret the 72 bits as 9 bytes (MSB-first).
+ *  - Bytes 4..7 are the inverted copy of bytes 0..3 (after XOR 0xFF they become equal).
+ *  - Restore MSB of B0 from MSB of B4: B0 = (B0 & 0x7F) | (B4 & 0x80).
+ *  - Verify checksum: tx8300_chk(B0..B3) == B8.
+ *
+ * Fields:
+ *  - humidity: BCD in B0
+ *  - channel: B1[5..4] (2-bit field)
+ *  - id (original 7-bit rolling/channel code): ((B1&0x07)<<4) | (B2>>4)  [overridden in code]
+ *  - temperature: BCD from B2/B3, sign in B1[3]
+ *  - lowbattery: B1 bit6
+ */
+
+function bitsToBytesMSB(bits72) {
+  const out = [];
+  for (let i = 0; i < bits72.length; i += 8) {
+    let b = 0;
+    for (let j = 0; j < 8; j++) b = (b << 1) | (bits72[i + j] & 1);
+    out.push(b & 0xFF);
+  }
+  return out;
+}
+
+function tx8300_chk(b0, b1, b2, b3) {
+  const arr = [b0 & 0xFF, b1 & 0xFF, b2 & 0xFF, b3 & 0xFF];
+  let x = 0, y = 0;
+  for (const v of arr) {
+    x += (v & 0x0F) + ((v & 0xF0) >> 4);
+    y += (v & 0x05) + ((v & 0x50) >> 4);
+  }
+  const c0 = (~(x & 0x0F)) & 0x0F;
+  const c1 = (~(y & 0x0F)) & 0x0F;
+  return ((c0 << 4) | c1) & 0xFF;
+}
+
+function postprocessAndValidate(bytes9) {
+  const B = bytes9.slice();
+
+  // invert copy bytes 4..7
+  for (let i = 4; i <= 7; i++) B[i] ^= 0xFF;
+
+  // restore MSB B0 from MSB of B4
+  B[0] = (B[0] & 0x7F) | (B[4] & 0x80);
+
+  // duplicate check
+  if (!(B[0] === B[4] && B[1] === B[5] && B[2] === B[6] && B[3] === B[7])) return null;
+
+  // checksum check
+  const chk = tx8300_chk(B[0], B[1], B[2], B[3]);
+  if (chk !== (B[8] & 0xFF)) return null;
+
+  return B;
+}
+
+class Bresser extends utils.WeatherSignal {
+  constructor() {
+    super({
+      id: 'Bresser',
+      name: 'Bresser',
+      /// NOTE: the signal is defined in app.json signals.433.Bresser)
+      signal: 'Bresser',
+      hint: {
+        en: 'Supports Bresser 7009995',
+        nl: 'Ondersteunt Bresser 7009995'
+      }
+    });
+  }
+
+  parse(payLoad) {
+    if (payLoad == null || typeof payLoad[Symbol.iterator] !== 'function') {
+      return new Error('Invalid payload');
+    }
+
+    const payload = Array.from(payLoad);
+
+    if (payload.length !== 72) {
+      return new Error('Expected 72 bits, got ' + payload.length);
+    }
+
+    // 72 bits as int 0/1
+    const bits72 = payLoad.map(b => (b === 1 || b === '1') ? 1 : 0);
+
+    const bytes9 = bitsToBytesMSB(bits72);
+    const B = postprocessAndValidate(bytes9);
+    if (!B) return new Error('MIC/checksum failed');
+
+    const b0 = B[0], b1 = B[1], b2 = B[2], b3 = B[3];
+
+    const humidity = ((b0 >> 4) & 0x0F) * 10 + (b0 & 0x0F);
+    const channel  = (b1 & 0x30) >> 4;
+
+    const lowbattery = (b1 & 0x40) !== 0; // bit6
+
+    const minus = (b1 & 0x08) !== 0;
+    const id = 9995 //((b1 & 0x07) << 4) | ((b2 & 0xF0) >> 4);
+
+    const tempAbs = (b2 & 0x0F) * 10 + ((b3 & 0xF0) >> 4) + (b3 & 0x0F) / 10.0;
+    const temperature = minus ? -tempAbs : tempAbs;
+
+    return {
+    id: String(id),
+    channel: channel,
+    data: { temperature: Number(temperature), humidity: humidity, lowbattery: lowbattery }
+    };
+  }
+}
+
+module.exports = {
+  Bresser: Bresser
+};

--- a/node_modules/protocols/index.js
+++ b/node_modules/protocols/index.js
@@ -3,6 +3,7 @@
 const alecto = require('./alecto.js');
 const ambient_weather = require('./ambient_weather.js');
 const auriol = require('./auriol.js');
+const bresser = require('./bresser.js');
 const cresta = require('./cresta.js');
 const lacrosse = require('./lacrosse.js');
 const oregon = require('./oregon.js');
@@ -14,6 +15,7 @@ let protocols = {
   ...alecto,
   ...ambient_weather,
   ...auriol,
+  ...bresser,
   ...cresta,
   ...lacrosse,
   ...oregon,

--- a/test/WeatherSignalTest.js
+++ b/test/WeatherSignalTest.js
@@ -178,6 +178,81 @@ var testSignals = [
     data: [1,1,0,0,1,0,0,0,0,0,1,0,0,0,1,0,0,0,0,0,0,0,0,0,1,1,0,1,1,1,1,1,0,0,0,1,1,1,0], protocol: "auriol2",
     result: {id:'200',channel:1,data:{temperature:22.3,humidity:34,lowbattery:false}}
   },
+/***************/
+/*** Bresser ***/
+/***************/
+  {
+    id: 'Bresser 7009995 #1',
+    data: [
+      1,0,1,1,0,1,0,1,
+      1,0,1,0,0,1,1,1,
+      1,0,1,0,0,0,1,0,
+      0,0,1,1,0,1,0,1,
+      1,1,0,0,1,0,1,0,
+      0,1,0,1,1,0,0,0,
+      0,1,0,1,1,1,0,1,
+      1,1,0,0,1,0,1,0,
+      0,0,1,0,1,1,1,0
+    ],
+    protocol: "Bresser",
+    result: {
+      id: '9995',
+      channel: 2,
+      data: {
+        temperature: 23.5,
+        humidity: 35,
+        lowbattery: false
+      }
+    }
+  },
+  {
+    id: 'Bresser 7009995 #2',
+    data: [
+      1,1,1,0,0,1,0,0,
+      1,0,0,1,1,1,0,1,
+      1,0,1,1,0,0,0,0,
+      0,0,0,0,0,0,1,1,
+      1,0,0,1,1,0,1,1,
+      0,1,1,0,0,0,1,0,
+      0,1,0,0,1,1,1,1,
+      1,1,1,1,1,1,0,0,
+      0,0,0,1,1,1,1,1
+    ],
+    protocol: "Bresser",
+    result: {
+      id: '9995',
+      channel: 1,
+      data: {
+        temperature: -0.3,
+        humidity: 64,
+        lowbattery: false
+      }
+    }
+  },
+  {
+    id: 'Bresser 7009995 #3',
+    data: [
+      1,1,0,1,0,1,0,0,
+      1,1,0,1,0,1,1,1,
+      1,1,1,0,0,0,1,0,
+      0,1,0,0,0,0,0,1,
+      1,0,1,0,1,0,1,1,
+      0,0,1,0,1,0,0,0,
+      0,0,0,1,1,1,0,1,
+      1,0,1,1,1,1,1,0,
+      1,1,0,1,0,0,1,1
+    ],
+    protocol: "Bresser",
+    result: {
+      id: '9995',
+      channel: 1,
+      data: {
+        temperature: 24.1,
+        humidity: 54,
+        lowbattery: true
+      }
+    }
+  },
 /**************/
 /*** Cresta ***/
 /**************/
@@ -374,6 +449,7 @@ for (var i = 0; i < testSignals.length; i++) {
   if (parsed) {
     delete result.protocol;
     delete result.lastupdate;
+	delete result.valid;
     if (ts.result !== undefined) {
       if (JSON.stringify(ts.result) === JSON.stringify(result)) {
         testResults.passed++;


### PR DESCRIPTION
## Summary

This PR adds support for Bresser 433 MHz temperature and humidity sensors.

## Changes

- Added Bresser protocol decoder.
- Registered Bresser in the protocols index.
- Added validation for payload length, checksum and decoded fields.
- Added regression tests based on captured Homey 433 MHz frames.
- Added test cases for validation results.

## Tested

I tested the decoder with captured Homey 433 MHz frames and verified:

- channel
- temperature
- humidity
- low battery flag

The regression tests were added to `test/WeatherSignalTest.js`.