### PR TITLE
Temperature Sensor TFA 30.3207.22

### DIFF
--- a/app.json
+++ b/app.json
@@ -1328,7 +1328,7 @@
 				]
 				],
 				"repetitions": 5,
-				"sensitivity": 0.25,
+				"sensitivity": 0.15,
 				"minimalLength": 34,
 				"maximalLength": 38
 			},

--- a/app.json
+++ b/app.json
@@ -1314,6 +1314,24 @@
 				"minimalLength": 60,
 				"maximalLength": 140
 			},
+			"Rubicson": {
+				"sof": [],
+				"eof": [],
+				"words": [
+				[
+					400,
+					900
+				],
+				[
+					400,
+					1900
+				]
+				],
+				"repetitions": 5,
+				"sensitivity": 0.25,
+				"minimalLength": 34,
+				"maximalLength": 38
+			},
 			"UPM": {
 				"sof": [
 					1000,

--- a/node_modules/protocols/tfa.js
+++ b/node_modules/protocols/tfa.js
@@ -67,7 +67,53 @@ class TFA extends utils.WeatherSignal {
 
 }
 
+class TFA30_3207 extends utils.WeatherSignal {
+
+  constructor() {
+    super({
+      id: 'tfa_30_3207',
+      name: 'TFA 30.3207',
+      signal: 'Rubicson',
+      hint: {
+        en: 'Support for TFA 30.3207 temperature sensor',
+        de: 'Unterstützung für TFA 30.3207 Temperatursensor',
+      }
+    });
+  }
+
+  parse(payLoad) {
+    let decVal = payLoad.join('');
+    let check = decVal.substr(24, 4);
+    if (check !== '1111') {
+      return new Error('Not a valid TFA message: check nibble not F: ' + check);
+    }
+    return this.decode(decVal);
+  }
+
+  decode(data) {
+    let id      = utils.bin2dec(data.substr(0, 8));
+    let batt    = data.substr(8, 1);
+    let channel = Number(utils.bin2dec(data.substr(10, 2))) + 1;
+
+    let value = utils.bin2dec(data.substr(12, 12));
+    if (value & 0x800) {
+      value ^= 0xfff;
+      value = -value - 1;
+    }
+
+    return {
+      id: id,
+      channel: channel,
+      data: {
+        temperature: value / 10,
+        lowbattery: (batt === '0'),
+      }
+    };
+  }
+}
+
 
 module.exports = {
-	tfa: TFA
+	tfa: TFA,
+	tfa_30_3207: TFA30_3207
 };


### PR DESCRIPTION
I added support for Temperature Sensor TFA 30.3207.22.

The signal used is Rubicson and the protocol is similar to auriol/nexus but without humidity as the sensor does not provide it and the data returned for humidity is garbage.